### PR TITLE
Fix not absolute path

### DIFF
--- a/lib/concatJS.js
+++ b/lib/concatJS.js
@@ -96,7 +96,7 @@ function concatJS(data) {
         for (const path of htmlPaths) {
           const html = htmls[path];
           if (front) {
-            html.$(`<script type="text/javascript" src="${route.format(bundlePath)}"></script>`).insertBefore(html.$('body>script').first());
+            html.$(`<script type="text/javascript" src="/${route.format(bundlePath)}"></script>`).insertBefore(html.$('body>script').first());
           } else {
             html.$('body').append(`<script type="text/javascript" src="/${route.format(bundlePath)}"></script>`);
           }


### PR DESCRIPTION
Fix not absolute path when `front: true`

Which will cause the child page lost the `bundle.js`