### PR TITLE
feat: replace minimatch with micromatch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - 6
+  - 8
 
 notifications:
   email:

--- a/lib/concatJS.js
+++ b/lib/concatJS.js
@@ -2,7 +2,7 @@
 
 const cheerio = require('cheerio');
 const Promise = require('bluebird');
-// const minimatch = require('minimatch');
+// const micromatch = require('micromatch');
 
 function concatJS(data) {
   const hexo = this;
@@ -15,7 +15,6 @@ function concatJS(data) {
   const routeList = route.list();
 
   // let include = options.include;
-  // if (include && !Array.isArray(include)) include = [include];
 
   // 1. get all local scripts
   const htmls = {};
@@ -78,7 +77,7 @@ function concatJS(data) {
               scripts.push(src);
             }
             // if (htmlPaths.every(path => htmls[path].srcs.indexOf(src) !== -1) ||
-            //   include.some(pattern => minimatch(src, pattern, { matchBase: true }))) {
+            //   include.some(pattern => micromatch.isMatch(src, pattern, { basename: true }))) {
             // }
           } else {
             // remove

--- a/lib/optimizeCSS.js
+++ b/lib/optimizeCSS.js
@@ -11,8 +11,13 @@ function OptimizeCSS(str, data) {
   var path = data.path;
   var exclude = options.exclude;
 
+  let enableBasename = true;
+  let excludeString = exclude;
+  if (exclude && Array.isArray(exclude)) excludeString = exclude.join('');
+  if (excludeString.includes('/')) enableBasename = false;
+
   if (path && exclude && exclude.length) {
-    if (micromatch.isMatch(path, exclude, {basename: true})) return str;
+    if (micromatch.isMatch(path, exclude, {basename: enableBasename})) return str;
   }
 
   var log = hexo.log || console;

--- a/lib/optimizeCSS.js
+++ b/lib/optimizeCSS.js
@@ -1,6 +1,6 @@
 'use strict';
 var CleanCSS = require('clean-css');
-var minimatch = require('minimatch');
+var micromatch = require('micromatch');
 
 function OptimizeCSS(str, data) {
   const hexo = this;
@@ -10,12 +10,9 @@ function OptimizeCSS(str, data) {
 
   var path = data.path;
   var exclude = options.exclude;
-  if (exclude && !Array.isArray(exclude)) exclude = [exclude];
 
   if (path && exclude && exclude.length) {
-    for (var i = 0, len = exclude.length; i < len; i++) {
-      if (minimatch(path, exclude[i], {matchBase: true})) return str;
-    }
+    if (micromatch.isMatch(path, exclude, {basename: true})) return str;
   }
 
   var log = hexo.log || console;

--- a/lib/optimizeHTML.js
+++ b/lib/optimizeHTML.js
@@ -1,6 +1,6 @@
 'use strict';
 const htmlminifier = require('html-minifier').minify;
-const minimatch = require('minimatch');
+const micromatch = require('micromatch');
 
 function OptimizeHTML(str, data) {
   const hexo = this;
@@ -10,12 +10,9 @@ function OptimizeHTML(str, data) {
 
   var path = data.path;
   var exclude = options.exclude;
-  if (exclude && !Array.isArray(exclude)) exclude = [exclude];
 
   if (path && exclude && exclude.length) {
-    for (var i = 0, len = exclude.length; i < len; i++) {
-      if (minimatch(path, exclude[i], {matchBase: true})) return str;
-    }
+    if (micromatch.isMatch(path, exclude, {basename: true})) return str;
   }
 
   const log = hexo.log || console;

--- a/lib/optimizeHTML.js
+++ b/lib/optimizeHTML.js
@@ -11,8 +11,13 @@ function OptimizeHTML(str, data) {
   var path = data.path;
   var exclude = options.exclude;
 
+  let enableBasename = true;
+  let excludeString = exclude;
+  if (exclude && Array.isArray(exclude)) excludeString = exclude.join('');
+  if (excludeString.includes('/')) enableBasename = false;
+
   if (path && exclude && exclude.length) {
-    if (micromatch.isMatch(path, exclude, {basename: true})) return str;
+    if (micromatch.isMatch(path, exclude, {basename: enableBasename})) return str;
   }
 
   const log = hexo.log || console;

--- a/lib/optimizeImage.js
+++ b/lib/optimizeImage.js
@@ -8,7 +8,7 @@ const optipng = require('imagemin-optipng');
 const svgo = require('imagemin-svgo');
 
 const Promise = require('bluebird');
-const minimatch = require('minimatch');
+const micromatch = require('micromatch');
 
 // Configure.
 
@@ -28,9 +28,9 @@ function OptimizeImage() {
 
   // exclude image
   var routes = route.list().filter((path) => {
-    return minimatch(path, '*.{' + targetfile.join(',') + '}', {
+    return micromatch.isMatch(path, '*.{' + targetfile.join(',') + '}', {
       nocase: true,
-      matchBase: true
+      basename: true
     });
   });
 

--- a/lib/optimizeJS.js
+++ b/lib/optimizeJS.js
@@ -11,8 +11,13 @@ function OptimizeJS(str, data) {
   var path = data.path;
   var exclude = options.exclude;
 
+  let enableBasename = true;
+  let excludeString = exclude;
+  if (exclude && Array.isArray(exclude)) excludeString = exclude.join('');
+  if (excludeString.includes('/')) enableBasename = false;
+
   if (path && exclude) {
-    if (micromatch.isMatch(path, exclude, {basename: true})) return str;
+    if (micromatch.isMatch(path, exclude, {basename: enableBasename})) return str;
   }
 
   const log = hexo.log || console;

--- a/lib/optimizeJS.js
+++ b/lib/optimizeJS.js
@@ -1,6 +1,6 @@
 'use strict';
 const UglifyJS = require('uglify-es');
-const minimatch = require('minimatch');
+const micromatch = require('micromatch');
 
 function OptimizeJS(str, data) {
   const hexo = this;
@@ -10,12 +10,9 @@ function OptimizeJS(str, data) {
 
   var path = data.path;
   var exclude = options.exclude;
-  if (exclude && !Array.isArray(exclude)) exclude = [exclude];
 
   if (path && exclude) {
-    for (var i = 0, len = exclude.length; i < len; i++) {
-      if (minimatch(path, exclude[i], {matchBase: true})) return str;
-    }
+    if (micromatch.isMatch(path, exclude, {basename: true})) return str;
   }
 
   const log = hexo.log || console;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3175,6 +3175,28 @@
         "is-glob": "^4.0.0",
         "merge2": "^1.2.3",
         "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        }
       }
     },
     "fast-json-stable-stringify": {
@@ -6217,23 +6239,43 @@
       "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
     },
     "micromatch": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "braces": "^3.0.1",
+        "picomatch": "^2.0.5"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
       }
     },
     "mime-db": {
@@ -6902,6 +6944,30 @@
           "requires": {
             "micromatch": "^3.1.4",
             "normalize-path": "^2.1.1"
+          },
+          "dependencies": {
+            "micromatch": {
+              "version": "3.1.10",
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+              "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              }
+            }
           }
         },
         "chokidar": {
@@ -7617,6 +7683,11 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
+    "picomatch": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
+      "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA=="
+    },
     "pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -7897,6 +7968,29 @@
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        }
       }
     },
     "redent": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "imagemin-optipng": "^6.0.0",
     "imagemin-pngquant": "^7.0.0",
     "imagemin-svgo": "^7.0.0",
-    "minimatch": "^3.0.4",
+    "micromatch": "^4.0.2",
     "uglify-es": "^3.3.9"
   },
   "devDependencies": {

--- a/test/concatJS.test.js
+++ b/test/concatJS.test.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const expect = require('chai').expect;
 const cheerio = require('cheerio');
-const minimatch = require('minimatch');
+const micromatch = require('micromatch');
 
 // Local modules.
 const concatJS = require('../lib/concatJS');
@@ -200,7 +200,7 @@ describe('ConcatJS', () => {
   //           }
   //         } else if (file.includes('script1.js') ||
   //           file.includes('script3.js') ||
-  //           [include].some(pattern => minimatch(file, pattern, { matchBase: true }))) {
+  //           [include].some(pattern => micromatch.isMatch(file, pattern, { basename: true }))) {
   //           expect(hexoRoute.buffer[format(file)], 'js file has been removed').to.be.undefined;
   //         }
   //         expect(hexoRoute.buffer[format(hexo.config.js_concator.bundle_path)]).to.has.length.greaterThan(0);
@@ -261,7 +261,7 @@ describe('ConcatJS', () => {
   //           }
   //         } else if (file.includes('script1.js') ||
   //           file.includes('script3.js') ||
-  //           include.some(pattern => minimatch(file, pattern, { matchBase: true }))) {
+  //           include.some(pattern => micromatch(file, pattern, { matchBase: true }))) {
   //           expect(hexoRoute.buffer[format(file)], 'js file has been removed').to.be.undefined;
   //         }
   //         expect(hexoRoute.buffer[format(hexo.config.js_concator.bundle_path)]).to.has.length.greaterThan(0);

--- a/test/optimizeCSS.test.js
+++ b/test/optimizeCSS.test.js
@@ -24,27 +24,6 @@ describe('OptimizeCSS', () => {
     expect(cssMinifier.call(hexo)).to.be.undefined;
   });
 
-  describe('exclude options', () => {
-    it('should warp the exclude to an array if it is not an array', () => {
-      const hexo = {
-        config: {
-          css_minifier: {
-            enable: true,
-            exclude: 'src/**/*'
-          }
-        },
-        log: {
-          info: () => {}
-        }
-      };
-      const str = 'strstr';
-      const datas = [{ path: 'src/usr/absolute' }, { path: 'src/test.txt' }];
-      for (const data of datas) {
-        expect(cssMinifier.call(hexo, str, data)).to.deep.equal(str);
-      }
-    });
-  });
-
   it('should minify css', () => {
     const hexo = {
       config: {

--- a/test/optimizeHTML.test.js
+++ b/test/optimizeHTML.test.js
@@ -43,17 +43,6 @@ describe('OptimizeHTML', () => {
     hexo.config.html_minifier.enable = true;
   });
 
-  describe('exclude options', () => {
-    it('should warp the exclude to an array if it is not an array', () => {
-
-      const str = 'strstr';
-      const datas = [{ path: 'src/usr/absolute' }, { path: 'src/test.txt' }];
-      for (const data of datas) {
-        expect(htmlMinifier.call(hexo, str, data)).to.deep.equal(str);
-      }
-    });
-  });
-
   it('should minify html', () => {
     for (const data of htmls) {
       expect(htmlMinifier.call(hexo, data.str, data)).to.have.length.lessThan(data.str.length);

--- a/test/optimizeImage.test.js
+++ b/test/optimizeImage.test.js
@@ -105,7 +105,7 @@ describe('hexo-image-minifier', () => {
     return promise.then(() => {
       for (const file of fixtures) {
         if (targetFile.indexOf(path.extname(file)) !== -1
-          && !micromatch.isMatch(file, exclude, { nocase: true, basename: true })) {
+          && micromatch.isMatch(file, exclude, { nocase: true, basename: true })) {
           expect(hexoRoute.buffer[file]).to.be.ok;
           expect(fileSize[file]).to.be.greaterThan(hexoRoute.buffer[file].length);
         } else {

--- a/test/optimizeImage.test.js
+++ b/test/optimizeImage.test.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const chai = require('chai');
 chai.use(require('chai-spies'));
-const minimatch = require('minimatch');
+const micromatch = require('micromatch');
 
 const expect = chai.expect;
 
@@ -105,7 +105,7 @@ describe('hexo-image-minifier', () => {
     return promise.then(() => {
       for (const file of fixtures) {
         if (targetFile.indexOf(path.extname(file)) !== -1
-          && exclude.every(pattern => !minimatch(file, pattern, { nocase: true, matchBase: true }))) {
+          && !micromatch.isMatch(file, exclude, { nocase: true, basename: true })) {
           expect(hexoRoute.buffer[file]).to.be.ok;
           expect(fileSize[file]).to.be.greaterThan(hexoRoute.buffer[file].length);
         } else {

--- a/test/optimizeImage.test.js
+++ b/test/optimizeImage.test.js
@@ -105,7 +105,7 @@ describe('hexo-image-minifier', () => {
     return promise.then(() => {
       for (const file of fixtures) {
         if (targetFile.indexOf(path.extname(file)) !== -1
-          && micromatch.isMatch(file, exclude, { nocase: true, basename: true })) {
+          && !micromatch.isMatch(file, exclude, { nocase: true, basename: true })) {
           expect(hexoRoute.buffer[file]).to.be.ok;
           expect(fileSize[file]).to.be.greaterThan(hexoRoute.buffer[file].length);
         } else {

--- a/test/optimizeJS.test.js
+++ b/test/optimizeJS.test.js
@@ -19,24 +19,6 @@ describe('OptimizeJS', () => {
     expect(jsMinifier.call(hexo)).to.be.undefined;
   });
 
-  describe('exclude options', () => {
-    it('should warp the exclude to an array if it is not an array', () => {
-      const hexo = {
-        config: {
-          js_minifier: {
-            enable: true,
-            exclude: 'src/**/*'
-          }
-        }
-      };
-      const str = 'strstr';
-      const datas = [{ path: 'src/usr/absolute' }, { path: 'src/test.txt' }];
-      for (const data of datas) {
-        expect(jsMinifier.call(hexo, str, data)).to.deep.equal(str);
-      }
-    });
-  });
-
   it('should minify js', () => {
     const hexo = {
       config: {


### PR DESCRIPTION
micromatch is a replacement of minimatch. It supports multiple patterns in an array, without the need of string-to-array conversion, along with other globbing [features](https://github.com/micromatch/picomatch#library-comparisons).

Depends on Node 8 or above.

More details: https://github.com/hexojs/hexo/pull/3538