### PR TITLE
fix: issue #87

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,13 @@ js_concator:
   bundle_path: '/js/bundle.js'
   front: false
   silent: false
+  prefix: ''
 ```
 - **enable** - Enable the Js concator. Defaults to `false`.
 - **bundle_path** - The output path of the bundle script. It will be set as absolute path to the root dir.
 - **front** - Put the bundle script in the front of all scripts in `body` tag. Default to `false`, which means the bundle script will be placed in the back of other scripts.
 - **silent** - Disable logging optimize informations. Defaults to `false`.
+- **prefix** - Add CDN prefix before bundle file.
 
 The concator will concat all local scripts into one bundle script and attach it to the end of html's `body` tag.
 More detail control will be allowed in the future version.

--- a/index.js
+++ b/index.js
@@ -54,7 +54,8 @@ if (isEnabled) {
     enable: false,
     bundle_path: 'js/bundle.js',
     front: false,
-    silent: false
+    silent: false,
+    prefix: ''
   }, hexo.config.js_concator);
 
   hexo.extend.filter.register('after_render:html', require('./lib/optimizeHTML'));

--- a/lib/concatJS.js
+++ b/lib/concatJS.js
@@ -96,7 +96,7 @@ function concatJS(data) {
         for (const path of htmlPaths) {
           const html = htmls[path];
           if (front) {
-            html.$(`<script type="text/javascript" src="${route.format(bundlePath)}"></script>`).insertBefore(html.$('body>script').first());
+            html.$(`<script type="text/javascript" src="/${route.format(bundlePath)}"></script>`).insertBefore(html.$('body>script').first());
           } else {
             html.$('body').append(`<script type="text/javascript" src="/${route.format(bundlePath)}"></script>`);
           }

--- a/lib/concatJS.js
+++ b/lib/concatJS.js
@@ -21,6 +21,7 @@ function concatJS(data) {
   const htmls = {};
   const bundlePath = options.bundle_path;
   const front = options.front;
+  const prefix = options.prefix;
   return Promise.all(routeList.filter(path => path.endsWith('.html')).map(path => {
     // 1. get the htmls that has local scripts
     return new Promise((resolve, reject) => {
@@ -96,9 +97,9 @@ function concatJS(data) {
         for (const path of htmlPaths) {
           const html = htmls[path];
           if (front) {
-            html.$(`<script type="text/javascript" src="/${route.format(bundlePath)}"></script>`).insertBefore(html.$('body>script').first());
+            html.$(`<script type="text/javascript" src="${prefix}/${route.format(bundlePath)}"></script>`).insertBefore(html.$('body>script').first());
           } else {
-            html.$('body').append(`<script type="text/javascript" src="/${route.format(bundlePath)}"></script>`);
+            html.$('body').append(`<script type="text/javascript" src="${prefix}/${route.format(bundlePath)}"></script>`);
           }
           route.set(path, html.$.html());
           log[options.silent ? 'debug' : 'info']('update Concate JS: add /%s to %s', route.format(bundlePath), path);


### PR DESCRIPTION
* 修复当启用front选项时，二级页面不能正确引用合并后的js文件
* 新特性：为使用CDN分发静态文件的用户提供自定义CDN前缀支持