### PR TITLE
fix: script could be undefined

### DIFF
--- a/lib/concatJS.js
+++ b/lib/concatJS.js
@@ -114,6 +114,12 @@ function concatJS(data) {
         return new Promise((resolve, reject) => {
           const script = route.get(path);
           let scriptTxt = '';
+          if (!script) {
+            log[options.silent ? 'debug' : 'info']('update Concate JS: script %s is not found, skipping', path);
+            route.remove(path);
+            resolve("");
+            return;
+          }
           script.on('data', chunk => (scriptTxt += chunk));
           script.on('end', () => {
             route.remove(path);


### PR DESCRIPTION
Sometimes the script could return an empty value, we ignore that anyway. Fixes #52.